### PR TITLE
token: app -> instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ type Client interface {
 func NewClient(instanceLocator string, key string) (Client, error)
 
 // NewChatkitUserToken and NewChatkitSUToken are Chatkit JWT token generation helper functions
-func NewChatkitUserToken(appID string, keyID string, keySecret string, userID string, expiryDuration time.Duration) (tokenString string, expiry time.Time, err error)
-func NewChatkitSUToken(appID string, keyID string, keySecret string, expiryDuration time.Duration) (tokenString string, expiry time.Time, err error)
+func NewChatkitUserToken(instanceID string, keyID string, keySecret string, userID string, expiryDuration time.Duration) (tokenString string, expiry time.Time, err error)
+func NewChatkitSUToken(instanceID string, keyID string, keySecret string, expiryDuration time.Duration) (tokenString string, expiry time.Time, err error)
 ```
 
 ## Installation

--- a/token_test.go
+++ b/token_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewChatkitSUTokenNoSub(t *testing.T) {
-	token, expiry, err := NewChatkitSUToken("appID", "keyID", "keySecret", nil, time.Hour)
+	token, expiry, err := NewChatkitSUToken("instanceID", "keyID", "keySecret", nil, time.Hour)
 	assert.NoError(t, err, "expect no error")
 
 	assert.False(t, time.Now().After(expiry), "expiry should be after now")
@@ -39,7 +39,7 @@ func TestNewChatkitSUTokenNoSub(t *testing.T) {
 
 func TestNewChatkitSUTokenWithSub(t *testing.T) {
 	sub := "jane"
-	token, expiry, err := NewChatkitSUToken("appID", "keyID", "keySecret", &sub, time.Hour)
+	token, expiry, err := NewChatkitSUToken("instanceID", "keyID", "keySecret", &sub, time.Hour)
 	assert.NoError(t, err, "expect no error")
 
 	assert.False(t, time.Now().After(expiry), "expiry should be after now")
@@ -66,7 +66,7 @@ func TestNewChatkitSUTokenWithSub(t *testing.T) {
 }
 
 func TestNewChatkitUserToken(t *testing.T) {
-	token, expiry, err := NewChatkitUserToken("appID", "keyID", "keySecret", "bob", time.Hour)
+	token, expiry, err := NewChatkitUserToken("instanceID", "keyID", "keySecret", "bob", time.Hour)
 	assert.NoError(t, err, "expect no error")
 
 	assert.False(t, time.Now().After(expiry), "expiry should be after now")


### PR DESCRIPTION
Migrates to using the `instance` claim instead of the `app` claim in tokens, and also cleans up any remaining references to app IDs