### PR TITLE
Fix Room Update PN title override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-go/compare/2.1.0...HEAD)
 
+### Fixes
+
+- Make it possible to clear a previously defined push notification title override
+
 ## [2.1.0](https://github.com/pusher/chatkit-server-go/compare/2.1.0...2.0.0)
 
 ### Additions

--- a/aliases.go
+++ b/aliases.go
@@ -47,3 +47,5 @@ type (
 	Part                          = core.Part
 	Attachment                    = core.Attachment
 )
+
+var ExplicitlyResetPushNotificationTitleOverride = &core.ExplicitlyResetPushNotificationTitleOverride

--- a/client_test.go
+++ b/client_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pusher/chatkit-server-go/internal/core"
 	"github.com/pusher/pusher-platform-go/auth"
 	platformclient "github.com/pusher/pusher-platform-go/client"
 	. "github.com/smartystreets/goconvey/convey"
@@ -725,7 +724,7 @@ func TestRooms(t *testing.T) {
 
 				err := client.UpdateRoom(ctx, room.ID, UpdateRoomOptions{
 					Name:                          &newRoomName,
-					PushNotificationTitleOverride: &core.ExplicitlyResetPushNotificationTitleOverride,
+					PushNotificationTitleOverride: ExplicitlyResetPushNotificationTitleOverride,
 					CustomData:                    map[string]interface{}{"foo": "baz"},
 				})
 				So(err, ShouldBeNil)


### PR DESCRIPTION
I didn't realise the `internal/core` package couldn't be imported by customers.

This PR fixes it by exposing the variable as a sort of an "alias".