### PR TITLE
Return RoomWithoutMembers from GetRooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-go/compare/2.1.1...HEAD)
 
+### Fixes
+
+- Return new type from GetRooms that better indicates that room members are
+  not returned
+
 ## [2.1.1](https://github.com/pusher/chatkit-server-go/compare/2.1.1...2.1.0)
 
 ### Fixes

--- a/aliases.go
+++ b/aliases.go
@@ -42,6 +42,7 @@ type (
 	FetchMultipartMessagesOptions = core.FetchMultipartMessagesOptions
 	User                          = core.User
 	Room                          = core.Room
+	RoomWithoutMembers            = core.RoomWithoutMembers
 	Message                       = core.Message
 	MultipartMessage              = core.MultipartMessage
 	Part                          = core.Part

--- a/client.go
+++ b/client.go
@@ -278,7 +278,7 @@ func (c *Client) GetRoom(ctx context.Context, roomID string) (Room, error) {
 }
 
 // GetRooms retrieves a list of rooms based on the options provided.
-func (c *Client) GetRooms(ctx context.Context, options GetRoomsOptions) ([]Room, error) {
+func (c *Client) GetRooms(ctx context.Context, options GetRoomsOptions) ([]core.RoomWithoutMembers, error) {
 	return c.coreServiceV6.GetRooms(ctx, options)
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -35,7 +35,7 @@ type Service interface {
 
 	// Rooms
 	GetRoom(ctx context.Context, roomID string) (Room, error)
-	GetRooms(ctx context.Context, options GetRoomsOptions) ([]Room, error)
+	GetRooms(ctx context.Context, options GetRoomsOptions) ([]RoomWithoutMembers, error)
 	GetUserRooms(ctx context.Context, userID string) ([]Room, error)
 	GetUserJoinableRooms(ctx context.Context, userID string) ([]Room, error)
 	CreateRoom(ctx context.Context, options CreateRoomOptions) (Room, error)
@@ -271,7 +271,7 @@ func (cs *coreService) GetRoom(ctx context.Context, roomID string) (Room, error)
 }
 
 // GetRooms retrieves a list of rooms with the given parameters.
-func (cs *coreService) GetRooms(ctx context.Context, options GetRoomsOptions) ([]Room, error) {
+func (cs *coreService) GetRooms(ctx context.Context, options GetRoomsOptions) ([]RoomWithoutMembers, error) {
 	queryParams := url.Values{}
 	if options.FromID != nil {
 		queryParams.Add("from_id", *options.FromID)
@@ -293,7 +293,7 @@ func (cs *coreService) GetRooms(ctx context.Context, options GetRoomsOptions) ([
 	}
 	defer response.Body.Close()
 
-	var rooms []Room
+	var rooms []RoomWithoutMembers
 	err = common.DecodeResponseBody(response.Body, &rooms)
 	if err != nil {
 		return nil, err

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -17,15 +17,8 @@ type User struct {
 
 // Room represents a chatkit room.
 type Room struct {
-	ID                            string      `json:"id"`                                         // ID assigned to a room
-	CreatedByID                   string      `json:"created_by_id"`                              // User ID that created the room
-	Name                          string      `json:"name"`                                       // Name assigned to the room
-	PushNotificationTitleOverride *string     `json:"push_notification_title_override,omitempty"` // Optionally override Push Notification title
-	Private                       bool        `json:"private"`                                    // Indicates if room is private or not
-	MemberUserIDs                 []string    `json:"member_user_ids,omitempty"`                  // List of user id's in the room
-	CustomData                    interface{} `json:"custom_data,omitempty"`                      // Custom data that can be added to rooms
-	CreatedAt                     time.Time   `json:"created_at"`                                 // Creation timestamp
-	UpdatedAt                     time.Time   `json:"updated_at"`                                 // Updation timestamp
+	RoomWithoutMembers
+	MemberUserIDs []string `json:"member_user_ids,omitempty"` // List of user id's in the room
 }
 
 // RoomWithoutMembers represents a chatkit room without listing its members.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -28,6 +28,18 @@ type Room struct {
 	UpdatedAt                     time.Time   `json:"updated_at"`                                 // Updation timestamp
 }
 
+// RoomWithoutMembers represents a chatkit room without listing its members.
+type RoomWithoutMembers struct {
+	ID                            string      `json:"id"`                                         // ID assigned to a room
+	CreatedByID                   string      `json:"created_by_id"`                              // User ID that created the room
+	Name                          string      `json:"name"`                                       // Name assigned to the room
+	PushNotificationTitleOverride *string     `json:"push_notification_title_override,omitempty"` // Optionally override Push Notification title
+	Private                       bool        `json:"private"`                                    // Indicates if room is private or not
+	CustomData                    interface{} `json:"custom_data,omitempty"`                      // Custom data that can be added to rooms
+	CreatedAt                     time.Time   `json:"created_at"`                                 // Creation timestamp
+	UpdatedAt                     time.Time   `json:"updated_at"`                                 // Updation timestamp
+}
+
 type messageIsh interface {
 	isMessageIsh()
 }


### PR DESCRIPTION
We don't return members from the /rooms endpoint - customers have found is confusing that the SDK shows this field as always empty rather than missing