### PR TITLE
Adds `FetchMultipartMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-go/compare/3.0.0...HEAD)
 
+### Additions
+
+- Support for fetching a message by its message ID, via `FetchMultipartMessage`.
+
 ## [3.0.0](https://github.com/pusher/chatkit-server-go/compare/3.0.0...2.1.1)
 
 ### Changes
@@ -25,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Additions
 
 - Support for `PushNotificationTitleOverride` attribute in the Room model and
-corresponding Update and Create structs.
+  corresponding Update and Create structs.
 
 ## [2.0.0](https://github.com/pusher/chatkit-server-go/compare/1.2.0...2.0.0)
 
@@ -36,7 +40,7 @@ corresponding Update and Create structs.
 
 ### Changes
 
-- The `DeleteMessage` method now *requires* a room ID parameter, `RoomID`, and
+- The `DeleteMessage` method now _requires_ a room ID parameter, `RoomID`, and
   the `ID` parameter has been renamed to `MessageId` to avoid ambiguity.
 
 ## [1.2.0](https://github.com/pusher/chatkit-server-go/compare/1.1.0...1.2.0)
@@ -73,4 +77,4 @@ everything has changed and refer to the [GoDoc][].
 - `NewChatkitToken` has been added and essentially replaces `NewChatkitSUToken` and `NewChatkitUserToken`
 - `Authenticate` added to `Client`
 
-[GoDoc]: http://godoc.org/github.com/pusher/chatkit-server-go
+[godoc]: http://godoc.org/github.com/pusher/chatkit-server-go

--- a/aliases.go
+++ b/aliases.go
@@ -39,6 +39,7 @@ type (
 	NewAttachmentPart             = core.NewAttachmentPart
 	GetRoomMessagesOptions        = core.GetRoomMessagesOptions
 	DeleteMessageOptions          = core.DeleteMessageOptions
+	FetchMultipartMessageOptions  = core.FetchMultipartMessageOptions
 	FetchMultipartMessagesOptions = core.FetchMultipartMessagesOptions
 	User                          = core.User
 	Room                          = core.Room

--- a/client.go
+++ b/client.go
@@ -348,6 +348,13 @@ func (c *Client) GetRoomMessages(
 	return c.coreServiceV2.GetRoomMessages(ctx, roomID, options)
 }
 
+func (c *Client) FetchMultipartMessage(
+	ctx context.Context,
+	options FetchMultipartMessageOptions,
+) (MultipartMessage, error) {
+	return c.coreServiceV6.FetchMultipartMessage(ctx, options)
+}
+
 // FetchMultipartMessages retrieves messages previously sent to a room based on
 // the options provided.
 func (c *Client) FetchMultipartMessages(

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -53,6 +53,10 @@ type Service interface {
 		roomID string,
 		options GetRoomMessagesOptions,
 	) ([]Message, error)
+	FetchMultipartMessage(
+		ctx context.Context,
+		options FetchMultipartMessageOptions,
+	) (MultipartMessage, error)
 	FetchMultipartMessages(
 		ctx context.Context,
 		roomID string,
@@ -726,6 +730,32 @@ func (cs *coreService) GetRoomMessages(
 	messages := []Message{}
 	err := cs.fetchMessages(ctx, roomID, options, &messages)
 	return messages, err
+}
+
+func (cs *coreService) FetchMultipartMessage(
+	ctx context.Context,
+	options FetchMultipartMessageOptions,
+) (MultipartMessage, error) {
+	response, err := common.RequestWithSuToken(
+		cs.underlyingInstance,
+		ctx,
+		client.RequestOptions{
+			Method: http.MethodGet,
+			Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
+		},
+	)
+	if err != nil {
+		return MultipartMessage{}, err
+	}
+	defer response.Body.Close()
+
+	var message MultipartMessage
+	err = common.DecodeResponseBody(response.Body, &message)
+	if err != nil {
+		return MultipartMessage{}, err
+	}
+
+	return message, nil
 }
 
 // FetchMultipartMessages fetches messages sent to a room based on the passed in options.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -184,6 +184,12 @@ type uploadedAttachment struct {
 	ID string `json:"id"`
 }
 
+// FetchMultipartMessageOptions contains parameters to pass when fetching a single message from a room.
+type FetchMultipartMessageOptions struct {
+	RoomID    string
+	MessageID uint
+}
+
 type fetchMessagesOptions struct {
 	InitialID *uint   // Starting ID of messages to retrieve
 	Direction *string // One of older or newer


### PR DESCRIPTION
### What?
Adds `fetchMultipartMessage` method.

### Why?
This allows you to retrieve a specific message by its message ID, which was previously unsupported.

