### PR TITLE
Add EditMessage methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-go/compare/3.1.0...HEAD)
 
+### Additions
+
+- Adds message editing via `Edit{Simple,Multipart,}Message`.
+
+### Fixes
+
+- Parameters passed in URL components are now URL encoded.
+- Response bodies are Close'd even if an err occurs.
+
 ## [3.1.0](https://github.com/pusher/chatkit-server-go/compare/3.0.0...3.1.0)
 
 ### Additions

--- a/aliases.go
+++ b/aliases.go
@@ -39,6 +39,9 @@ type (
 	NewAttachmentPart             = core.NewAttachmentPart
 	GetRoomMessagesOptions        = core.GetRoomMessagesOptions
 	DeleteMessageOptions          = core.DeleteMessageOptions
+	EditMessageOptions            = core.EditMessageOptions
+	EditSimpleMessageOptions      = core.EditSimpleMessageOptions
+	EditMultipartMessageOptions   = core.EditMultipartMessageOptions
 	FetchMultipartMessagesOptions = core.FetchMultipartMessagesOptions
 	User                          = core.User
 	Room                          = core.Room

--- a/client.go
+++ b/client.go
@@ -363,6 +363,21 @@ func (c *Client) DeleteMessage(ctx context.Context, options DeleteMessageOptions
 	return c.coreServiceV6.DeleteMessage(ctx, options)
 }
 
+// EditMessage replaces an existing message in a room.
+func (c *Client) EditMessage(ctx context.Context, options EditMessageOptions) error {
+	return c.coreServiceV2.EditMessage(ctx, options)
+}
+
+// EditMultipartMessage replaces an existing message in a room with a multipart message.
+func (c *Client) EditMultipartMessage(ctx context.Context, options EditMultipartMessageOptions) error {
+	return c.coreServiceV6.EditMultipartMessage(ctx, options)
+}
+
+// EditSimpleMessage replaces an existing message in a room a simple multipart message.
+func (c *Client) EditSimpleMessage(ctx context.Context, options EditSimpleMessageOptions) error {
+	return c.coreServiceV6.EditSimpleMessage(ctx, options)
+}
+
 // CoreRequest allows making requests to the core chatkit service and returns a raw HTTP response.
 func (c *Client) CoreRequest(
 	ctx context.Context,

--- a/client_test.go
+++ b/client_test.go
@@ -303,6 +303,7 @@ func TestAuthorizer(t *testing.T) {
 			Name:        roomRoleName,
 			Permissions: roomPermissions,
 		})
+		So(err, ShouldBeNil)
 
 		Convey("it should be possible to fetch them", func() {
 			roles, err := client.GetRoles(context.Background())

--- a/client_test.go
+++ b/client_test.go
@@ -1162,6 +1162,11 @@ func TestEditMessages(t *testing.T) {
 			})
 
 		})
+
+		Reset(func() {
+			err := deleteAllResources(client)
+			So(err, ShouldBeNil)
+		})
 	})
 
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1045,21 +1045,6 @@ func TestMessages(t *testing.T) {
 				So(messages[0].Parts[4].Attachment.CustomData, ShouldBeNil)
 				So(messages[0].Parts[4].Attachment.DownloadURL, ShouldNotEqual, "")
 			})
-
-			Convey("and delete it", func() {
-				err := client.DeleteMessage(ctx, DeleteMessageOptions{
-					RoomID:    room.ID,
-					MessageID: messageID,
-				})
-				So(err, ShouldBeNil)
-
-				limit := uint(1)
-				messages, err := client.GetRoomMessages(ctx, room.ID, GetRoomMessagesOptions{
-					Limit: &limit,
-				})
-				So(err, ShouldBeNil)
-				So(len(messages), ShouldEqual, 0)
-			})
 		})
 
 		Reset(func() {
@@ -1067,4 +1052,84 @@ func TestMessages(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+}
+
+func TestEditMessages(t *testing.T) {
+	ctx := context.Background()
+
+	config, err := getConfig()
+	if err != nil {
+		t.Fatalf("Failed to get test config: %s", err.Error())
+	}
+
+	client, err := NewClient(config.instanceLocator, config.key)
+	if err != nil {
+		t.Fatalf("Failed to create client: %s", err.Error())
+	}
+
+	Convey("Given a user and a room with messages", t, func() {
+		userID, err := createUser(client)
+		So(err, ShouldBeNil)
+
+		room, err := client.CreateRoom(ctx, CreateRoomOptions{
+			Name:      randomString(),
+			CreatorID: userID,
+		})
+		So(err, ShouldBeNil)
+
+		messageID1, err := client.SendMessage(ctx, SendMessageOptions{
+			RoomID:   room.ID,
+			Text:     "one",
+			SenderID: userID,
+		})
+		So(err, ShouldBeNil)
+
+		messageID2, err := client.SendSimpleMessage(ctx, SendSimpleMessageOptions{
+			RoomID:   room.ID,
+			Text:     "two",
+			SenderID: userID,
+		})
+		So(err, ShouldBeNil)
+
+		messageID3, err := client.SendMultipartMessage(ctx, SendMultipartMessageOptions{
+			RoomID:   room.ID,
+			SenderID: userID,
+			Parts: []NewPart{
+				NewInlinePart{Type: "text/plain", Content: "three"},
+			}})
+		So(err, ShouldBeNil)
+
+		Convey("Messages can be edited", func() {
+			Convey("Messages can be edited using the v2 api", func() {
+				err := client.EditMessage(ctx, EditMessageOptions{
+					RoomID:    room.ID,
+					MessageID: messageID1,
+					Text:      "one-edited",
+					SenderID:  userID,
+				})
+				So(err, ShouldBeNil)
+			})
+			Convey("Messages can be edited using simple multipart messages", func() {
+				err := client.EditSimpleMessage(ctx, EditSimpleMessageOptions{
+					RoomID:    room.ID,
+					MessageID: messageID2,
+					Text:      "two-edited",
+					SenderID:  userID,
+				})
+				So(err, ShouldBeNil)
+			})
+			Convey("Messages can be edited using multipart messages", func() {
+				err := client.EditMultipartMessage(ctx, EditMultipartMessageOptions{
+					RoomID:    room.ID,
+					MessageID: messageID3,
+					SenderID:  userID,
+					Parts: []NewPart{
+						NewInlinePart{Type: "text/plain", Content: "three-edited"},
+					}})
+				So(err, ShouldBeNil)
+			})
+
+		})
+	})
+
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -88,10 +88,12 @@ func (cs *coreService) GetUser(ctx context.Context, userID string) (User, error)
 		Method: http.MethodGet,
 		Path:   fmt.Sprintf("/users/%s", userID),
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return User{}, err
 	}
-	defer response.Body.Close()
 
 	var user User
 	err = common.DecodeResponseBody(response.Body, &user)
@@ -139,10 +141,12 @@ func (cs *coreService) GetUsersByID(ctx context.Context, userIDs []string) ([]Us
 			"id": userIDs,
 		},
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
 
 	var users []User
 	err = common.DecodeResponseBody(response.Body, &users)
@@ -173,10 +177,12 @@ func (cs *coreService) CreateUser(ctx context.Context, options CreateUserOptions
 		Path:   "/users",
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -198,10 +204,12 @@ func (cs *coreService) CreateUsers(ctx context.Context, users []CreateUserOption
 		Path:   "/batch_users",
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -226,10 +234,12 @@ func (cs *coreService) UpdateUser(
 		Path:   fmt.Sprintf("/users/%s", userID),
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -245,10 +255,12 @@ func (cs *coreService) DeleteUser(ctx context.Context, userID string) error {
 		Method: http.MethodDelete,
 		Path:   fmt.Sprintf("/users/%s", userID),
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -259,10 +271,12 @@ func (cs *coreService) GetRoom(ctx context.Context, roomID string) (Room, error)
 		Method: http.MethodGet,
 		Path:   fmt.Sprintf("/rooms/%s", roomID),
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return Room{}, err
 	}
-	defer response.Body.Close()
 
 	var room Room
 	err = common.DecodeResponseBody(response.Body, &room)
@@ -291,10 +305,12 @@ func (cs *coreService) GetRooms(ctx context.Context, options GetRoomsOptions) ([
 		Path:        "/rooms",
 		QueryParams: &queryParams,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
 
 	var rooms []RoomWithoutMembers
 	err = common.DecodeResponseBody(response.Body, &rooms)
@@ -336,10 +352,12 @@ func (cs *coreService) getRoomsForUser(
 		Path:        fmt.Sprintf("/users/%s/rooms", userID),
 		QueryParams: &queryParams,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
 
 	var rooms []Room
 	err = common.DecodeResponseBody(response.Body, &rooms)
@@ -374,10 +392,12 @@ func (cs *coreService) CreateRoom(ctx context.Context, options CreateRoomOptions
 			Body:   requestBody,
 		},
 	)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return Room{}, err
 	}
-	defer response.Body.Close()
 
 	var room Room
 	err = common.DecodeResponseBody(response.Body, &room)
@@ -413,10 +433,12 @@ func (cs *coreService) UpdateRoom(ctx context.Context, roomID string, options Up
 		Path:   fmt.Sprintf("/rooms/%s", roomID),
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -427,10 +449,12 @@ func (cs *coreService) DeleteRoom(ctx context.Context, roomID string) error {
 		Method: http.MethodDelete,
 		Path:   fmt.Sprintf("/rooms/%s", roomID),
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -452,10 +476,12 @@ func (cs *coreService) AddUsersToRoom(ctx context.Context, roomID string, userID
 		Path:   fmt.Sprintf("/rooms/%s/users/add", roomID),
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -477,10 +503,12 @@ func (cs *coreService) RemoveUsersFromRoom(ctx context.Context, roomID string, u
 		Path:   fmt.Sprintf("/rooms/%s/users/remove", roomID),
 		Body:   requestBody,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -509,10 +537,12 @@ func (cs *coreService) SendMessage(ctx context.Context, options SendMessageOptio
 			Path:   fmt.Sprintf("/rooms/%s/messages", options.RoomID),
 			Body:   requestBody,
 		})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return 0, err
 	}
-	defer response.Body.Close()
 
 	var messageResponse map[string]uint
 	err = common.DecodeResponseBody(response.Body, &messageResponse)
@@ -574,10 +604,12 @@ func (cs *coreService) SendMultipartMessage(
 			Body:   requestBody,
 		},
 	)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return 0, err
 	}
-	defer response.Body.Close()
 
 	var messageResponse map[string]uint
 	err = common.DecodeResponseBody(response.Body, &messageResponse)
@@ -653,10 +685,12 @@ func (cs *coreService) requestPresignedURL(
 			Body:   body,
 		},
 	)
+	if res != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return "", "", err
 	}
-	defer res.Body.Close()
 
 	var resBody map[string]string
 	if err := common.DecodeResponseBody(res.Body, &resBody); err != nil {
@@ -683,10 +717,12 @@ func (cs *coreService) uploadToURL(
 	req.Header.Add("content-length", strconv.Itoa(contentLength))
 
 	res, err := client.Do(req.WithContext(ctx))
+	if res != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status: %v", res.Status)
 	}
@@ -712,10 +748,12 @@ func (cs *coreService) DeleteMessage(ctx context.Context, options DeleteMessageO
 		Method: http.MethodDelete,
 		Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -748,10 +786,12 @@ func (cs *coreService) EditMessage(ctx context.Context, options EditMessageOptio
 			Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
 			Body:   requestBody,
 		})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -818,10 +858,12 @@ func (cs *coreService) EditMultipartMessage(ctx context.Context, options EditMul
 			Body:   requestBody,
 		},
 	)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	return nil
 }
@@ -872,10 +914,12 @@ func (cs *coreService) fetchMessages(
 		Path:        fmt.Sprintf("/rooms/%s/messages", roomID),
 		QueryParams: &queryParams,
 	})
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
 	err = common.DecodeResponseBody(response.Body, target)
 	if err != nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -571,14 +571,14 @@ func (cs *coreService) SendMultipartMessage(
 	}
 
 	requestParts := make([]interface{}, len(options.Parts))
-	g := errgroup.Group{}
+	g, gCtx := errgroup.WithContext(ctx)
 
 	for i, part := range options.Parts {
 		switch p := part.(type) {
 		case NewAttachmentPart:
 			i := i
 			g.Go(func() error {
-				uploadedPart, err := cs.uploadAttachment(ctx, options.SenderID, options.RoomID, p)
+				uploadedPart, err := cs.uploadAttachment(gCtx, options.SenderID, options.RoomID, p)
 				requestParts[i] = uploadedPart
 				return err
 			})
@@ -825,14 +825,14 @@ func (cs *coreService) EditMultipartMessage(ctx context.Context, options EditMul
 	}
 
 	requestParts := make([]interface{}, len(options.Parts))
-	g := errgroup.Group{}
+	g, gCtx := errgroup.WithContext(ctx)
 
 	for i, part := range options.Parts {
 		switch p := part.(type) {
 		case NewAttachmentPart:
 			i := i
 			g.Go(func() error {
-				uploadedPart, err := cs.uploadAttachment(ctx, options.SenderID, options.RoomID, p)
+				uploadedPart, err := cs.uploadAttachment(gCtx, options.SenderID, options.RoomID, p)
 				requestParts[i] = uploadedPart
 				return err
 			})

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -184,7 +184,7 @@ func (cs *coreService) CreateUser(ctx context.Context, options CreateUserOptions
 // CreateUsers creates users in a batch.
 // A maximum of 10 users can be created per batch.
 func (cs *coreService) CreateUsers(ctx context.Context, users []CreateUserOptions) error {
-	if users == nil || len(users) == 0 {
+	if len(users) == 0 {
 		return errors.New("You must provide a list of users to create")
 	}
 
@@ -438,7 +438,7 @@ func (cs *coreService) DeleteRoom(ctx context.Context, roomID string) error {
 // AddUsersToRoom adds users to an existing room.
 // The maximum number of users that can be added in a single request is 10.
 func (cs *coreService) AddUsersToRoom(ctx context.Context, roomID string, userIDs []string) error {
-	if userIDs == nil || len(userIDs) == 0 {
+	if len(userIDs) == 0 {
 		return errors.New("You must provide a list of IDs of the users you want to add to the room")
 	}
 
@@ -463,7 +463,7 @@ func (cs *coreService) AddUsersToRoom(ctx context.Context, roomID string, userID
 // RemoveUsersFromRoom removes a list of users from the room.
 // The maximum number of users that can be removed in a single request is 10.
 func (cs *coreService) RemoveUsersFromRoom(ctx context.Context, roomID string, userIDs []string) error {
-	if userIDs == nil || len(userIDs) == 0 {
+	if len(userIDs) == 0 {
 		return errors.New("You must provide a list of IDs of the users you want to remove from the room")
 	}
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -86,7 +86,7 @@ func (cs *coreService) GetUser(ctx context.Context, userID string) (User, error)
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodGet,
-		Path:   fmt.Sprintf("/users/%s", userID),
+		Path:   fmt.Sprintf("/users/%s", url.PathEscape(userID)),
 	})
 	if response != nil {
 		defer response.Body.Close()
@@ -231,7 +231,7 @@ func (cs *coreService) UpdateUser(
 
 	response, err := common.RequestWithUserToken(cs.underlyingInstance, ctx, userID, client.RequestOptions{
 		Method: http.MethodPut,
-		Path:   fmt.Sprintf("/users/%s", userID),
+		Path:   fmt.Sprintf("/users/%s", url.PathEscape(userID)),
 		Body:   requestBody,
 	})
 	if response != nil {
@@ -253,7 +253,7 @@ func (cs *coreService) DeleteUser(ctx context.Context, userID string) error {
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodDelete,
-		Path:   fmt.Sprintf("/users/%s", userID),
+		Path:   fmt.Sprintf("/users/%s", url.PathEscape(userID)),
 	})
 	if response != nil {
 		defer response.Body.Close()
@@ -269,7 +269,7 @@ func (cs *coreService) DeleteUser(ctx context.Context, userID string) error {
 func (cs *coreService) GetRoom(ctx context.Context, roomID string) (Room, error) {
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodGet,
-		Path:   fmt.Sprintf("/rooms/%s", roomID),
+		Path:   fmt.Sprintf("/rooms/%s", url.PathEscape(roomID)),
 	})
 	if response != nil {
 		defer response.Body.Close()
@@ -349,7 +349,7 @@ func (cs *coreService) getRoomsForUser(
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method:      http.MethodGet,
-		Path:        fmt.Sprintf("/users/%s/rooms", userID),
+		Path:        fmt.Sprintf("/users/%s/rooms", url.PathEscape(userID)),
 		QueryParams: &queryParams,
 	})
 	if response != nil {
@@ -430,7 +430,7 @@ func (cs *coreService) UpdateRoom(ctx context.Context, roomID string, options Up
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodPut,
-		Path:   fmt.Sprintf("/rooms/%s", roomID),
+		Path:   fmt.Sprintf("/rooms/%s", url.PathEscape(roomID)),
 		Body:   requestBody,
 	})
 	if response != nil {
@@ -447,7 +447,7 @@ func (cs *coreService) UpdateRoom(ctx context.Context, roomID string, options Up
 func (cs *coreService) DeleteRoom(ctx context.Context, roomID string) error {
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodDelete,
-		Path:   fmt.Sprintf("/rooms/%s", roomID),
+		Path:   fmt.Sprintf("/rooms/%s", url.PathEscape(roomID)),
 	})
 	if response != nil {
 		defer response.Body.Close()
@@ -473,7 +473,7 @@ func (cs *coreService) AddUsersToRoom(ctx context.Context, roomID string, userID
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodPut,
-		Path:   fmt.Sprintf("/rooms/%s/users/add", roomID),
+		Path:   fmt.Sprintf("/rooms/%s/users/add", url.PathEscape(roomID)),
 		Body:   requestBody,
 	})
 	if response != nil {
@@ -500,7 +500,7 @@ func (cs *coreService) RemoveUsersFromRoom(ctx context.Context, roomID string, u
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodPut,
-		Path:   fmt.Sprintf("/rooms/%s/users/remove", roomID),
+		Path:   fmt.Sprintf("/rooms/%s/users/remove", url.PathEscape(roomID)),
 		Body:   requestBody,
 	})
 	if response != nil {
@@ -534,7 +534,7 @@ func (cs *coreService) SendMessage(ctx context.Context, options SendMessageOptio
 		options.SenderID,
 		client.RequestOptions{
 			Method: http.MethodPost,
-			Path:   fmt.Sprintf("/rooms/%s/messages", options.RoomID),
+			Path:   fmt.Sprintf("/rooms/%s/messages", url.PathEscape(options.RoomID)),
 			Body:   requestBody,
 		})
 	if response != nil {
@@ -600,7 +600,7 @@ func (cs *coreService) SendMultipartMessage(
 		options.SenderID,
 		client.RequestOptions{
 			Method: http.MethodPost,
-			Path:   fmt.Sprintf("/rooms/%s/messages", options.RoomID),
+			Path:   fmt.Sprintf("/rooms/%s/messages", url.PathEscape(options.RoomID)),
 			Body:   requestBody,
 		},
 	)
@@ -681,7 +681,7 @@ func (cs *coreService) requestPresignedURL(
 		senderID,
 		client.RequestOptions{
 			Method: http.MethodPost,
-			Path:   fmt.Sprintf("/rooms/%s/attachments", roomID),
+			Path:   fmt.Sprintf("/rooms/%s/attachments", url.PathEscape(roomID)),
 			Body:   body,
 		},
 	)
@@ -746,7 +746,7 @@ func (cs *coreService) SendSimpleMessage(
 func (cs *coreService) DeleteMessage(ctx context.Context, options DeleteMessageOptions) error {
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method: http.MethodDelete,
-		Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
+		Path:   fmt.Sprintf("/rooms/%s/messages/%d", url.PathEscape(options.RoomID), options.MessageID),
 	})
 	if response != nil {
 		defer response.Body.Close()
@@ -783,7 +783,7 @@ func (cs *coreService) EditMessage(ctx context.Context, options EditMessageOptio
 		options.SenderID,
 		client.RequestOptions{
 			Method: http.MethodPut,
-			Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
+			Path:   fmt.Sprintf("/rooms/%s/messages/%d", url.PathEscape(options.RoomID), options.MessageID),
 			Body:   requestBody,
 		})
 	if response != nil {
@@ -854,7 +854,7 @@ func (cs *coreService) EditMultipartMessage(ctx context.Context, options EditMul
 		options.SenderID,
 		client.RequestOptions{
 			Method: http.MethodPut,
-			Path:   fmt.Sprintf("/rooms/%s/messages/%d", options.RoomID, options.MessageID),
+			Path:   fmt.Sprintf("/rooms/%s/messages/%d", url.PathEscape(options.RoomID), options.MessageID),
 			Body:   requestBody,
 		},
 	)
@@ -911,7 +911,7 @@ func (cs *coreService) fetchMessages(
 
 	response, err := common.RequestWithSuToken(cs.underlyingInstance, ctx, client.RequestOptions{
 		Method:      http.MethodGet,
-		Path:        fmt.Sprintf("/rooms/%s/messages", roomID),
+		Path:        fmt.Sprintf("/rooms/%s/messages", url.PathEscape(roomID)),
 		QueryParams: &queryParams,
 	})
 	if response != nil {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -145,6 +145,23 @@ type SendSimpleMessageOptions struct {
 	SenderID string
 }
 
+type EditMessageOptions = EditSimpleMessageOptions
+
+// EditSimpleMessageOption contains parameters to pass when editing an existing message.
+type EditSimpleMessageOptions struct {
+	RoomID    string
+	MessageID uint
+	SenderID  string
+	Text      string
+}
+
+type EditMultipartMessageOptions struct {
+	RoomID    string
+	MessageID uint
+	SenderID  string
+	Parts     []NewPart
+}
+
 type NewPart interface {
 	isNewPart()
 }


### PR DESCRIPTION
Adds functions for (upcoming) message editing endpoints.

Riders:
- URL encode parameters before splicing them into URLs
- Close response bodies if they exist, even if an error occurs