### PR TITLE
EditRoomMessage takes room and message ids as separate parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-go/compare/3.1.0...HEAD)
 
-## [3.2.0](https://github.com/pusher/chatkit-server-go/compare/3.1.0...3.2.0)
+## [3.3.0](https://github.com/pusher/chatkit-server-go/compare/3.1.0...3.3.0)
 
 ### Additions
 
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Parameters passed in URL components are now URL encoded.
 - Response bodies are Close'd even if an err occurs.
+
+## 3.2.0 Yanked
 
 ## [3.1.0](https://github.com/pusher/chatkit-server-go/compare/3.0.0...3.1.0)
 

--- a/client.go
+++ b/client.go
@@ -371,19 +371,22 @@ func (c *Client) DeleteMessage(ctx context.Context, options DeleteMessageOptions
 	return c.coreServiceV6.DeleteMessage(ctx, options)
 }
 
-// EditMessage replaces an existing message in a room.
-func (c *Client) EditMessage(ctx context.Context, options EditMessageOptions) error {
-	return c.coreServiceV2.EditMessage(ctx, options)
+// EditMessage identifies an existing message by both its room and message id
+// in order to replace it's content and sender id with updated values.
+func (c *Client) EditMessage(ctx context.Context, roomID string, messageID uint, options EditMessageOptions) error {
+	return c.coreServiceV2.EditMessage(ctx, roomID, messageID, options)
 }
 
-// EditMultipartMessage replaces an existing message in a room with a multipart message.
-func (c *Client) EditMultipartMessage(ctx context.Context, options EditMultipartMessageOptions) error {
-	return c.coreServiceV6.EditMultipartMessage(ctx, options)
+// EditMultipartMessage identifies an existing message by both its room and message id
+// in order to replace it's content and sender id with updated values.
+func (c *Client) EditMultipartMessage(ctx context.Context, roomID string, messageID uint, options EditMultipartMessageOptions) error {
+	return c.coreServiceV6.EditMultipartMessage(ctx, roomID, messageID, options)
 }
 
-// EditSimpleMessage replaces an existing message in a room a simple multipart message.
-func (c *Client) EditSimpleMessage(ctx context.Context, options EditSimpleMessageOptions) error {
-	return c.coreServiceV6.EditSimpleMessage(ctx, options)
+// EditSimpleMessage identifies an existing message by both its room and message id
+// in order to replace it's content and sender id with updated values.
+func (c *Client) EditSimpleMessage(ctx context.Context, roomID string, messageID uint, options EditSimpleMessageOptions) error {
+	return c.coreServiceV6.EditSimpleMessage(ctx, roomID, messageID, options)
 }
 
 // CoreRequest allows making requests to the core chatkit service and returns a raw HTTP response.

--- a/client_test.go
+++ b/client_test.go
@@ -1133,28 +1133,22 @@ func TestEditMessages(t *testing.T) {
 
 		Convey("Messages can be edited", func() {
 			Convey("Messages can be edited using the v2 api", func() {
-				err := client.EditMessage(ctx, EditMessageOptions{
-					RoomID:    room.ID,
-					MessageID: messageID1,
-					Text:      "one-edited",
-					SenderID:  userID,
+				err := client.EditMessage(ctx, room.ID, messageID1, EditMessageOptions{
+					Text:     "one-edited",
+					SenderID: userID,
 				})
 				So(err, ShouldBeNil)
 			})
 			Convey("Messages can be edited using simple multipart messages", func() {
-				err := client.EditSimpleMessage(ctx, EditSimpleMessageOptions{
-					RoomID:    room.ID,
-					MessageID: messageID2,
-					Text:      "two-edited",
-					SenderID:  userID,
+				err := client.EditSimpleMessage(ctx, room.ID, messageID2, EditSimpleMessageOptions{
+					Text:     "two-edited",
+					SenderID: userID,
 				})
 				So(err, ShouldBeNil)
 			})
 			Convey("Messages can be edited using multipart messages", func() {
-				err := client.EditMultipartMessage(ctx, EditMultipartMessageOptions{
-					RoomID:    room.ID,
-					MessageID: messageID3,
-					SenderID:  userID,
+				err := client.EditMultipartMessage(ctx, room.ID, messageID3, EditMultipartMessageOptions{
+					SenderID: userID,
 					Parts: []NewPart{
 						NewInlinePart{Type: "text/plain", Content: "three-edited"},
 					}})

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -149,17 +149,13 @@ type EditMessageOptions = EditSimpleMessageOptions
 
 // EditSimpleMessageOption contains parameters to pass when editing an existing message.
 type EditSimpleMessageOptions struct {
-	RoomID    string
-	MessageID uint
-	SenderID  string
-	Text      string
+	SenderID string
+	Text     string
 }
 
 type EditMultipartMessageOptions struct {
-	RoomID    string
-	MessageID uint
-	SenderID  string
-	Parts     []NewPart
+	SenderID string
+	Parts    []NewPart
 }
 
 type NewPart interface {


### PR DESCRIPTION
Adjust editMessage api to clarify that roomID and messageID identify the message to edit.